### PR TITLE
Améliorations UI DCA et reset DB

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,7 +1,16 @@
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('dca-form');
+    const calcBtn = form.querySelector('button[type="submit"]');
+    const calcSpinner = document.getElementById('calc-spinner');
+    const exportBtn = document.getElementById('export-btn');
+    const resetBtn = document.getElementById('reset-btn');
+    const resetSpinner = document.getElementById('reset-spinner');
+    const resetMsg = document.getElementById('reset-msg');
+
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
+        calcBtn.disabled = true;
+        calcSpinner.classList.remove('d-none');
         const amount = parseFloat(document.getElementById('amount').value);
         const start = document.getElementById('start').value;
         const freq = document.getElementById('frequency').value;
@@ -13,70 +22,105 @@ document.addEventListener('DOMContentLoaded', () => {
         const data = await res.json();
         displayResults(data);
         drawDcaChart(data.progress);
+        drawBtcChart(data.progress);
+        drawPerfChart(data.progress);
+        exportBtn.classList.remove('d-none');
+        exportBtn.onclick = () => exportCsv(data.purchases);
+        calcSpinner.classList.add('d-none');
+        calcBtn.disabled = false;
     });
 
     fetch('/api/chart-data')
         .then(r => r.json())
         .then(drawCharts);
+
+    resetBtn.addEventListener('click', async () => {
+        if(!confirm('Confirmer la r\u00e9initialisation de la base ?')) return;
+        resetBtn.disabled = true;
+        resetMsg.textContent = '';
+        resetSpinner.classList.remove('d-none');
+        const res = await fetch('/reset-db', {method:'POST'});
+        const data = await res.json();
+        if(data.success){
+            document.getElementById('date-range').textContent = `Donn\u00e9es disponibles : ${data.min_date} \u00e0 ${data.max_date}`;
+            resetMsg.className = 'text-success';
+            resetMsg.textContent = 'Base r\u00e9initialis\u00e9e avec succ\u00e8s';
+        }else{
+            resetMsg.className = 'text-danger';
+            resetMsg.textContent = 'Erreur : ' + data.error;
+        }
+        resetSpinner.classList.add('d-none');
+        resetBtn.disabled = false;
+    });
 });
 
-function displayResults(data) {
-    const div = document.getElementById('results');
-    div.innerHTML = `
-    <h3>Résultats DCA</h3>
-    <table class="table table-bordered">
-        <tr><th>Nombre d'achats</th><td>${data.num_purchases}</td></tr>
-        <tr><th>Total investi</th><td>${data.total_invested.toFixed(2)} USD</td></tr>
-        <tr><th>Total BTC acheté</th><td>${data.total_btc.toFixed(6)} BTC</td></tr>
-        <tr><th>Valeur finale</th><td>${data.final_value.toFixed(2)} USD</td></tr>
-        <tr><th>Performance</th><td>${data.performance_pct.toFixed(2)} %</td></tr>
-    </table>`;
+function exportCsv(purchases){
+    let csv = 'date,amount_usd,btc,price_usd\n';
+    purchases.forEach(p => {
+        csv += `${p.date},${p.amount},${p.btc},${p.price}\n`;
+    });
+    const blob = new Blob([csv], {type:'text/csv'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'dca_purchases.csv';
+    a.click();
+    URL.revokeObjectURL(url);
 }
 
-function drawCharts(dataset) {
+let priceChart, fgChart, dcaChart, btcChart, perfChart;
+const baseOptions = {
+    responsive: true,
+    scales: { x: { type: 'time', time: { unit: 'month' } } },
+    plugins: { zoom: { zoom: { wheel: {enabled: true}, pinch:{enabled:true}, mode:'x' }, pan: {enabled:true, mode:'x'} } }
+};
+
+function drawCharts(dataset){
     const ctx1 = document.getElementById('priceChart').getContext('2d');
-    new Chart(ctx1, {
+    if(priceChart) priceChart.destroy();
+    priceChart = new Chart(ctx1, {
         type: 'line',
-        data: {
-            labels: dataset.dates,
-            datasets: [{
-                label: 'BTC Price',
-                data: dataset.prices,
-                borderColor: 'blue',
-                fill: false
-            }]
-        }
+        data: { labels: dataset.dates, datasets: [{ label: 'Prix BTC (USD)', data: dataset.prices, borderColor: 'blue', fill:false }] },
+        options: baseOptions
     });
 
     const ctx2 = document.getElementById('fgChart').getContext('2d');
-    new Chart(ctx2, {
+    if(fgChart) fgChart.destroy();
+    fgChart = new Chart(ctx2, {
         type: 'line',
-        data: {
-            labels: dataset.dates,
-            datasets: [{
-                label: 'Fear & Greed',
-                data: dataset.fg,
-                borderColor: 'orange',
-                fill: false
-            }]
-        }
+        data: { labels: dataset.dates, datasets: [{ label: 'Fear & Greed', data: dataset.fg, borderColor:'orange', fill:false }] },
+        options: baseOptions
     });
 }
 
-function drawDcaChart(progress) {
-    const labels = progress.map(p => p.date);
-    const values = progress.map(p => p.value);
+function drawDcaChart(progress){
     const ctx = document.getElementById('dcaChart').getContext('2d');
-    new Chart(ctx, {
-        type: 'line',
-        data: {
-            labels: labels,
-            datasets: [{
-                label: 'Valeur DCA',
-                data: values,
-                borderColor: 'green',
-                fill: false
-            }]
-        }
+    if(dcaChart) dcaChart.destroy();
+    const line = progress.map(p => ({x:p.date, y:p.value}));
+    const markers = progress.filter(p=>p.buy).map(p=>({x:p.date, y:p.value}));
+    dcaChart = new Chart(ctx, {
+        type:'line',
+        data:{ datasets:[{ label:'Valeur DCA (USD)', data: line, borderColor:'green', fill:false }, { type:'scatter', label:'Achats', data: markers, pointBackgroundColor:'red', showLine:false }] },
+        options: baseOptions
+    });
+}
+
+function drawBtcChart(progress){
+    const ctx = document.getElementById('btcChart').getContext('2d');
+    if(btcChart) btcChart.destroy();
+    btcChart = new Chart(ctx, {
+        type:'line',
+        data:{ datasets:[{ label:'BTC accumul\u00e9', data: progress.map(p=>({x:p.date,y:p.btc})), borderColor:'purple', fill:false }] },
+        options: baseOptions
+    });
+}
+
+function drawPerfChart(progress){
+    const ctx = document.getElementById('perfChart').getContext('2d');
+    if(perfChart) perfChart.destroy();
+    perfChart = new Chart(ctx, {
+        type:'line',
+        data:{ datasets:[{ label:'Performance relative', data: progress.map(p=>({x:p.date,y:p.perf_rel})), borderColor:'teal', fill:false }] },
+        options: baseOptions
     });
 }

--- a/static/style.css
+++ b/static/style.css
@@ -24,3 +24,7 @@ form {
 canvas {
     margin-top: 40px;
 }
+
+#reset-msg {
+    min-height: 1.5em;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,10 +6,18 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.umd.min.js"></script>
 </head>
 <body>
 <div class="container">
     <h1 class="my-4 text-center">Bitcoin Dashboard</h1>
+    <div class="alert alert-info text-center" id="date-range">Données disponibles : {{ min_date }} à {{ max_date }}</div>
+    <div class="mb-3 text-center">
+        <button id="reset-btn" class="btn btn-warning">🔁 Réinitialiser la base de données</button>
+        <span id="reset-spinner" class="spinner-border spinner-border-sm d-none" role="status"></span>
+        <div id="reset-msg" class="mt-2"></div>
+    </div>
     <form id="dca-form">
         <div class="row g-3">
             <div class="col-md-4">
@@ -30,13 +38,17 @@
             </div>
         </div>
         <button type="submit" class="btn btn-primary mt-3">Calculer</button>
+        <span id="calc-spinner" class="spinner-border spinner-border-sm ms-2 d-none" role="status"></span>
     </form>
 
-    <div id="results"></div>
+    <div id="results" class="mt-3"></div>
+    <button id="export-btn" class="btn btn-secondary my-3 d-none">Exporter les résultats CSV</button>
 
     <canvas id="priceChart" height="100"></canvas>
     <canvas id="fgChart" height="100"></canvas>
     <canvas id="dcaChart" height="100"></canvas>
+    <canvas id="btcChart" height="100"></canvas>
+    <canvas id="perfChart" height="100"></canvas>
 </div>
 
 <script src="{{ url_for('static', filename='script.js') }}"></script>


### PR DESCRIPTION
## Summary
- calcul DCA journalier et benchmark lump sum
- portée des dates dispo dans le gabarit
- bouton de réinitialisation de la base avec spinner
- graphiques interactifs (zoom/pan) et accumulation/performance
- export CSV et indicateurs supplémentaires

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6843f90498908320bedc3b671d473eab