### PR TITLE
Fix missing displayResults function

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -124,3 +124,17 @@ function drawPerfChart(progress){
         options: baseOptions
     });
 }
+
+function displayResults(data){
+    const div = document.getElementById('results');
+    div.innerHTML = `
+        <ul class="list-group">
+            <li class="list-group-item">Nombre d'achats : ${data.num_purchases}</li>
+            <li class="list-group-item">Investissement total : ${data.total_invested.toFixed(2)} USD</li>
+            <li class="list-group-item">Bitcoin accumulé : ${data.total_btc.toFixed(8)} BTC</li>
+            <li class="list-group-item">Valeur finale : ${data.final_value.toFixed(2)} USD</li>
+            <li class="list-group-item">Valeur en achat unique : ${data.lump_value.toFixed(2)} USD</li>
+            <li class="list-group-item">Performance : ${data.performance_pct.toFixed(2)}%</li>
+        </ul>
+    `;
+}


### PR DESCRIPTION
## Summary
- implement `displayResults` to show DCA output on the page

## Testing
- `curl -X POST -H "Content-Type: application/json" -d '{"amount": 100, "start": "2018-02-05", "frequency": "weekly"}' http://127.0.0.1:5000/api/dca | head`


------
https://chatgpt.com/codex/tasks/task_e_6843fad2c82883208cd030d51635195e