### PR TITLE
Add Fear & Greed based DCA simulation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -45,6 +45,10 @@
     <span id="best-spinner" class="spinner-border spinner-border-sm ms-2 d-none" role="status"></span>
     <div id="best-days" class="mt-3"></div>
 
+    <button id="smart-dca-btn" class="btn btn-success mt-3">💡 Simuler un DCA intelligent basé sur le Fear & Greed</button>
+    <span id="smart-spinner" class="spinner-border spinner-border-sm ms-2 d-none" role="status"></span>
+    <div id="smart-results" class="mt-3"></div>
+
     <div id="results" class="mt-3"></div>
     <button id="export-btn" class="btn btn-secondary my-3 d-none">Exporter les résultats CSV</button>
 


### PR DESCRIPTION
## Summary
- implement smart DCA using Fear & Greed Index
- hook smart DCA endpoint and UI
- add results table displaying bag usage

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import app, init_db
init_db()
client = app.test_client()
print(client.post('/api/smart-dca', json={'amount':100,'start':'2018-02-05','frequency':'weekly'}).status_code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68440365e898832095ee49c5bda6abc0