### PR TITLE
Fix smart DCA frontend interactions

### DIFF
--- a/app.py
+++ b/app.py
@@ -169,17 +169,28 @@ def dca():
 @app.route('/api/smart-dca', methods=['POST'])
 def smart_dca():
     """DCA adjusted using Fear & Greed Index."""
-    # Parameters specific to the smart DCA logic
-    fgi_threshold_high = 75
-    fgi_threshold_low = 30
-    bonus_from_bag_pct = 0.20
-    max_bonus_from_bag = 300
-
-    data = request.get_json()
+    data = request.get_json() or {}
     logging.info("/api/smart-dca params: %s", data)
     amount = float(data.get('amount'))
     start = data.get('start')
     freq = data.get('frequency')
+
+    def parse_int(val, default):
+        try:
+            return int(val)
+        except (TypeError, ValueError):
+            return default
+
+    def parse_float(val, default):
+        try:
+            return float(val)
+        except (TypeError, ValueError):
+            return default
+
+    fgi_threshold_high = parse_int(data.get('fg_threshold_high'), 75)
+    fgi_threshold_low = parse_int(data.get('fg_threshold_low'), 30)
+    bonus_from_bag_pct = parse_float(data.get('bag_bonus_pct'), 20) / 100
+    max_bonus_from_bag = parse_float(data.get('bag_bonus_max'), 300)
 
     conn = get_db_connection()
     rows = conn.execute('SELECT date, price, fg FROM data WHERE date >= ? ORDER BY date', (start,)).fetchall()

--- a/static/script.js
+++ b/static/script.js
@@ -1,3 +1,5 @@
+let smartDiv;
+
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('dca-form');
     const calcBtn = form.querySelector('button[type="submit"]');
@@ -11,7 +13,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const bestDiv = document.getElementById('best-days');
     const smartBtn = document.getElementById('smart-dca-btn');
     const smartSpinner = document.getElementById('smart-spinner');
-    const smartDiv = document.getElementById('smart-results');
+    smartDiv = document.getElementById('smart-dca-result');
+
+    const fgHighInput = document.getElementById('fg_threshold_high');
+    const fgLowInput = document.getElementById('fg_threshold_low');
+    const bagPctInput = document.getElementById('bag_bonus_pct');
+    const bagMaxInput = document.getElementById('bag_bonus_max');
 
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -64,10 +71,19 @@ document.addEventListener('DOMContentLoaded', () => {
         const amount = parseFloat(document.getElementById('amount').value);
         const start = document.getElementById('start').value;
         const freq = document.getElementById('frequency').value;
+        const body = {
+            amount,
+            start,
+            frequency: freq,
+            fg_threshold_high: parseFloat(fgHighInput.value),
+            fg_threshold_low: parseFloat(fgLowInput.value),
+            bag_bonus_pct: parseFloat(bagPctInput.value),
+            bag_bonus_max: parseFloat(bagMaxInput.value)
+        };
         const res = await fetch('/api/smart-dca', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ amount, start, frequency: freq })
+            body: JSON.stringify(body)
         });
         const data = await res.json();
         if(!res.ok){

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,13 +41,35 @@
         <span id="calc-spinner" class="spinner-border spinner-border-sm ms-2 d-none" role="status"></span>
     </form>
 
+    <div class="mt-4">
+        <h5>Paramètres avancés (DCA intelligent)</h5>
+        <div class="row g-3">
+            <div class="col-md-3">
+                <label class="form-label">Seuil haut FGI</label>
+                <input type="number" id="fg_threshold_high" class="form-control" value="75">
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Seuil bas FGI</label>
+                <input type="number" id="fg_threshold_low" class="form-control" value="30">
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">% du bag utilisé</label>
+                <input type="number" id="bag_bonus_pct" class="form-control" value="20">
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Plafond du bonus</label>
+                <input type="number" id="bag_bonus_max" class="form-control" value="300">
+            </div>
+        </div>
+    </div>
+
     <button id="best-days-btn" class="btn btn-info mt-3">🔍 Simuler les meilleurs jours d'investissement</button>
     <span id="best-spinner" class="spinner-border spinner-border-sm ms-2 d-none" role="status"></span>
     <div id="best-days" class="mt-3"></div>
 
     <button id="smart-dca-btn" class="btn btn-success mt-3">💡 Simuler un DCA intelligent basé sur le Fear & Greed</button>
     <span id="smart-spinner" class="spinner-border spinner-border-sm ms-2 d-none" role="status"></span>
-    <div id="smart-results" class="mt-3"></div>
+    <div id="smart-dca-result" class="mt-3"></div>
 
     <div id="results" class="mt-3"></div>
     <button id="export-btn" class="btn btn-secondary my-3 d-none">Exporter les résultats CSV</button>


### PR DESCRIPTION
## Summary
- send advanced parameters for smart DCA to backend
- show smart DCA results in dedicated element
- support advanced options form
- parse optional parameters in backend

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68440ee98f488320b40043d250ee80ef