### PR TITLE
Nettoyer les logs de debug

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,9 +10,6 @@ import logging
 import tempfile
 import traceback
 
-import os
-import tempfile
-
 # Détermination du dossier racine du projet
 # Sur Render, le code est placé dans `/opt/render/project/src` alors que
 # localement il se trouve dans le répertoire courant. Utiliser le
@@ -23,11 +20,6 @@ CSV_FILE = os.path.join(APP_ROOT, "data.csv")
 DB_NAME = os.path.join(tempfile.gettempdir(), "btc.db")
 
 
-print("=== DEBUG CHEMINS ===")
-print("APP_ROOT :", APP_ROOT)
-print("DB_NAME  :", DB_NAME)
-print("CSV_FILE :", CSV_FILE)
-print("=====================")
 
 app = Flask(__name__)
 
@@ -63,16 +55,13 @@ def log_request_end(response):
 
 
 def init_db(force: bool = False):
-    print("on est dedans")
     """Create the SQLite database from the CSV file."""
     try:
-        print(f"Chemin absolu de data.csv : {CSV_FILE}")
-        print(f"Chemin absolu de la base : {DB_NAME}")
         if force and os.path.exists(DB_NAME):
             os.remove(DB_NAME)
         if force or not os.path.exists(DB_NAME):
             df = pd.read_csv(CSV_FILE)
-            print("Lecture de data.csv OK, lignes :", len(df))
+            logging.info("Lecture de data.csv OK, lignes : %d", len(df))
             df['Date'] = pd.to_datetime(df['Date'], format='%d.%m.%Y')
             df['Date'] = df['Date'].dt.strftime('%Y-%m-%d')
             df['Price'] = df['Price'].str.replace(',', '.').astype(float)
@@ -88,11 +77,11 @@ def init_db(force: bool = False):
                           (row['Date'], row['Price'], int(row['fg'])))
             conn.commit()
             conn.close()
-            print("Création de btc.db terminée")
+            logging.info("Création de btc.db terminée")
         else:
-            print("btc.db déjà présent")
+            logging.info("btc.db déjà présent")
     except Exception as e:
-        print("❌ Erreur dans init_db :", e)
+        logging.error("❌ Erreur dans init_db : %s", e)
         raise
 
 init_db(force=True)


### PR DESCRIPTION
## Summary
- remove duplicate imports and debug prints
- use logging instead of print in DB initialization

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684671ef231c8320aa1d66c0b5c460b6