### PR TITLE
Move results above feature tabs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,9 @@
         </form>
     </div>
 
+    <div id="results" class="mt-3"></div>
+    <button id="export-btn" class="btn btn-secondary my-3 d-none">Exporter les résultats CSV</button>
+
     <div class="advanced-settings mb-4">
         <h5 class="mb-3">Paramètres avancés (DCA intelligent)</h5>
         <div class="row g-3">
@@ -105,9 +108,6 @@
         </div>
     </div>
 
-
-    <div id="results" class="mt-3"></div>
-    <button id="export-btn" class="btn btn-secondary my-3 d-none">Exporter les résultats CSV</button>
 
     <canvas id="priceChart" height="100"></canvas>
     <canvas id="fgChart" height="100"></canvas>


### PR DESCRIPTION
## Summary
- display DCA results right after the main settings block
- keep advanced settings and tabs below

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849ad86cdf483209a1e1e40ac186627