### PR TITLE
Fix Trends chart layout

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -49,7 +49,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     document.querySelectorAll('.trend-filter').forEach(btn=>{
-        btn.addEventListener('click', ()=>loadTrends(btn.dataset.period));
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.trend-filter').forEach(b=>b.classList.remove('active'));
+            btn.classList.add('active');
+            loadTrends(btn.dataset.period);
+        });
     });
     loadTrends('month');
 

--- a/static/style.css
+++ b/static/style.css
@@ -98,7 +98,10 @@ canvas {
 
 /* Bandeau Google Trends */
 #trends-container {
-    max-height: 200px;
+    height: 200px; /* hauteur fixe pour la zone */
+}
+#trendsChart {
+    height: 160px !important; /* garde une hauteur constante pour le canvas */
 }
 #trend-score {
     font-size: 1.5rem;


### PR DESCRIPTION
## Summary
- enforce a fixed height for the Google Trends chart
- highlight active trend filter buttons

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684a871fc8b88320b2205e3751c89692