### PR TITLE
Improve trends loading UX

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,7 @@
     <div id="trends-container" class="mb-3">
         <div class="d-flex justify-content-between align-items-center">
             <div id="trend-score"></div>
+            <span id="trends-spinner" class="spinner-border spinner-border-sm d-none"></span>
             <div>
                 <button class="btn btn-sm btn-outline-secondary trend-filter" data-period="all">Tout</button>
                 <button class="btn btn-sm btn-outline-secondary trend-filter" data-period="year">Année</button>


### PR DESCRIPTION
## Summary
- show a spinner next to Google trends score
- disable trend filter buttons while loading
- re-enable buttons and handle errors when the request completes

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ae42bdb6483208cc7990afa4a2297