### PR TITLE
Disable trend fetching on Render and handle empty data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,18 @@ python app.py
 ```
 
 L\'interface est disponible sur [http://localhost:5000](http://localhost:5000).
+
+## Préremplissage de la table `trends`
+
+Sur les plateformes où l'accès à Google Trends est bloqué (par exemple Render),
+il est conseillé de remplir la table `trends` en local avant le déploiement :
+
+1. Lancez l'application sur une machine non restreinte afin que les données
+   Google Trends soient enregistrées dans `btc.db`.
+2. Exportez la table au format SQL :
+   ```
+   sqlite3 /tmp/btc.db .dump trends > trends.sql
+   ```
+   (ou en CSV selon vos préférences).
+3. Importez ce fichier lors du déploiement – copie de la base ou exécution du
+   script SQL – pour éviter toute tentative de récupération automatique.

--- a/static/script.js
+++ b/static/script.js
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function loadTrends(period){
         trendsSpinner.classList.remove('d-none');
         trendBtns.forEach(b => b.disabled = true);
-        fetch(`/trends?period=${period}`)
+        fetch(`/api/trend-data?period=${period}`)
             .then(async r => {
                 let data;
                 try {
@@ -51,6 +51,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 return data;
             })
             .then(data => {
+                if(!data.scores || data.scores.length === 0 || data.error){
+                    if(trendsChart) trendsChart.destroy();
+                    trendScore.textContent = 'Tendance Google Trends indisponible actuellement';
+                    return;
+                }
                 const labels = data.scores.map(s=>s.date);
                 const vals = data.scores.map(s=>s.score);
                 if(trendsChart) trendsChart.destroy();


### PR DESCRIPTION
## Summary
- prevent automatic background fetching on Render deployments
- allow get_trends_json to skip downloads when data is missing
- expose `/api/trend-data` route returning cached-only trends
- handle unavailable trends gracefully in the frontend
- document how to preload the `trends` table

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ca8bf9c708320b4b3f9cbe5f7dd1e