### PR TITLE
Fix app syntax and trend fetch flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -443,7 +443,7 @@ def get_trends_json(period: str, fetch_if_missing: bool = True) -> dict:
 
     df = get_trends_from_db(period)
     required_days = (today - start).days + 1
-    if len(df) < required_days and allow_fetch:
+    if len(df) < required_days and fetch_if_missing:
         fetched = fetch_trend_series(start, today)
         save_trends_to_db(fetched)
         df = get_trends_from_db(period)
@@ -539,14 +539,12 @@ def simulate_smart_dca_rows(rows, step, amount, high, low, pct, bonus_max):
     return {
         'performance_pct': performance,
         'total_invested': invested,
+        'btc_total': btc_total,
+        'final_value': final_value,
+        'bag_used': bag_used,
+        'bag_remaining': bag,
+    }
 
-        now = time.time()
-        cached = TREND_CACHE.get(period)
-        if cached and now - cached[0] < TREND_TTL:
-            return jsonify(cached[1])
-
-
-        TREND_CACHE[period] = (now, out)
 @app.route('/api/chart-data')
 def chart_data():
     conn = get_db_connection()
@@ -580,7 +578,7 @@ def trend_data():
     period = request.args.get('period', 'month')
     try:
         allow_fetch = not os.getenv("RENDER")
-        out = get_trends_json(period, allow_fetch=allow_fetch)
+        out = get_trends_json(period, fetch_if_missing=allow_fetch)
         if not out['scores']:
             return jsonify({"scores": [], "error": "Tendance indisponible"}), 200
         return jsonify(out)


### PR DESCRIPTION
### Motivation
- Repair a syntax/logic regression that caused `app.py` to fail to compile and prevented callers from receiving the full smart‑DCA simulation metrics.
- Ensure Google Trends fetching respects the existing API flag that disables network access in restricted environments (e.g. Render).

### Description
- Close the `simulate_smart_dca_rows` result dictionary and restore returned fields `btc_total`, `final_value`, `bag_used`, and `bag_remaining` so downstream callers get the expected metrics.
- Remove stray, misplaced trend-cache lines that were accidentally embedded inside the simulation function and causing a syntax error. 
- Use the existing `fetch_if_missing` parameter in `get_trends_json` and pass it from the `/api/trend-data` route so network fetching is correctly gated when `RENDER` is set.

### Testing
- Ran `python -m compileall app.py` which succeeded and verified the file compiles. 
- Executed the built-in self-check via `RENDER=1 python - <<'PY' ... app._selftest() ... PY` which passed (`✅ self-test OK`).
- Performed route smoke tests with `RENDER=1` using the Flask test client for `/api/chart-data` and `/api/trend-data`, which returned HTTP 200 and passed.
- Ran `python -m pytest` which completed but collected no tests (no automated test cases present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19614a2724832082b07adc39c6fced)